### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for operator-bundle-2-4

### DIFF
--- a/Dockerfile.operator-bundle
+++ b/Dockerfile.operator-bundle
@@ -69,7 +69,8 @@ LABEL \
         url="https://github.com/rh-ecosystem-edge/kernel-module-management" \
         vendor="Red Hat, Inc." \
         distribution-scope="" \
-        name="kmm/kernel-module-management-operator-bundle-rhel9" \
+        name="kmm/kernel-module-management-operator-bundle" \
+        cpe="cpe:/a:redhat:kernel_module_management:2.4::el9" \
         License="Apache License 2.0" \
         io.k8s.display-name="Kernel Module Management" \
         io.openshift.tags="Operating System" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
