### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for operator-2-4

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -23,7 +23,8 @@ LABEL \
     com.redhat.component="kernel-module-management-operator-container" \
     version="${VERSION}" \
     release="${RELEASE}" \
-    name="kernel-module-management/kernel-module-management-rhel9-operator" \
+    name="kmm/kernel-module-management-rhel9-operator" \
+    cpe="cpe:/a:redhat:kernel_module_management:2.4::el9" \
     License="Apache License 2.0" \
     io.k8s.display-name="Kernel Module Management" \
     io.openshift.tags="Operating System" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
