### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for hub-operator-2-4

### DIFF
--- a/Dockerfile.hub-operator
+++ b/Dockerfile.hub-operator
@@ -26,7 +26,8 @@ LABEL \
     version="${VERSION}" \
     release="${RELEASE}" \
     git.commit="$CI_UPSTREAM_SHORT_COMMIT" \
-    name="kernel-module-management/kernel-module-management-hub-rhel9-operator" \
+    name="kmm/kernel-module-management-hub-rhel9-operator" \
+    cpe="cpe:/a:redhat:kernel_module_management:2.4::el9" \
     License="Apache License 2.0" \
     io.k8s.display-name="Kernel Module Management - Hub" \
     io.openshift.tags="Operating System" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
